### PR TITLE
Changes to allow proper launch on macOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ numpy>=1.18
 pandas>=0.24.0
 scipy>=1.2.0
 axographio>=0.3.1
+pyobjc-core>=6.2.2
+pyobjc-framework-Cocoa>=6.2.2
+python.app>=1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 pyqtgraph>=0.11.0rc0
-PySide2==5.14.0
+PySide2>=5.14.0
 numpy>=1.18
 pandas>=0.24.0
 scipy>=1.2.0
 axographio>=0.3.1
-pyobjc-core>=6.2.2
 pyobjc-framework-Cocoa>=6.2.2
-python.app>=1.3

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,12 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         "pyqtgraph>=0.11.0rc0",
-        "PySide2==5.14.0",
+        "PySide2>=5.14.0",
         "numpy>=1.18",
         "pandas>=0.24.0",
         "scipy>=1.2.0",
         "axographio>=0.3.1",
+	"pyobjc-framework-Cocoa>=6.2.2",
     ],
     entry_points={"console_scripts": ["ascam=src.ascam:main"]},
 )

--- a/src/ascam.py
+++ b/src/ascam.py
@@ -9,9 +9,17 @@ import logging
 import getopt
 
 from PySide2.QtWidgets import QApplication
-from .gui.mainwindow import MainWindow
-from .utils import initialize_logger
-
+try :
+    from .gui.mainwindow import MainWindow
+    
+except:
+    from src.gui.mainwindow import MainWindow
+    
+try :
+    from .utils import initialize_logger
+except :
+    from src.utils import initialize_logger
+    
 
 debug_logger = logging.getLogger("ascam.debug")
 
@@ -105,3 +113,21 @@ def main():
     if test:
         main_window.test_mode()
     sys.exit(app.exec_())
+    
+if __name__ == "__main__":
+    # Change menubar name from 'python' to 'SAFT' on macOS
+    # from https://stackoverflow.com/questions/5047734/
+    if sys.platform.startswith('darwin'):
+    # Python 3: pyobjc-framework-Cocoa is needed
+        try:
+            from Foundation import NSBundle
+            bundle = NSBundle.mainBundle()
+            if bundle:
+                app_name = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+                app_info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+                if app_info:
+                    app_info['CFBundleName'] = app_name.upper() # ensure text is in upper case.
+        except ImportError:
+            print ("Failed to import NSBundle, couldn't change menubar name." )
+        
+    main()


### PR DESCRIPTION
GUI must be launched with pythonw to have correct behaviour. Also, boilerplate code now imports pyobjc to allow the app name to be displayed in the menubar (only on darwin). relative imports are also bundled by try except.

now the command pythonw ASCAM/src/ascam.py launches ASCAM as a proper macOS app. 