### PR TITLE
Import QAbstractItemView from QWidget instead of QtGui.

### DIFF
--- a/src/gui/episode_frame.py
+++ b/src/gui/episode_frame.py
@@ -1,6 +1,6 @@
 import logging
 
-from PySide2 import QtCore, QtGui
+from PySide2 import QtCore
 from PySide2.QtWidgets import (
     QWidget,
     QListWidget,
@@ -13,6 +13,7 @@ from PySide2.QtWidgets import (
     QPushButton,
     QGridLayout,
     QComboBox,
+    QAbstractItemView,
 )
 
 
@@ -203,7 +204,7 @@ class EpisodeList(QListWidget):
     def __init__(self, parent, *args, **kwargs):
         super(EpisodeList, self).__init__(*args, **kwargs)
         self.parent = parent
-        self.setSelectionMode(QtGui.QAbstractItemView.ExtendedSelection)
+        self.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Expanding)
         self.currentItemChanged.connect(
             self.on_item_click, type=QtCore.Qt.DirectConnection

--- a/src/gui/io_widgets.py
+++ b/src/gui/io_widgets.py
@@ -1,4 +1,3 @@
-from PySide2 import QtGui
 from PySide2.QtWidgets import (
     QLineEdit,
     QDialog,
@@ -10,6 +9,7 @@ from PySide2.QtWidgets import (
     QFileDialog,
     QVBoxLayout,
     QHBoxLayout,
+    QAbstractItemView,
 )
 
 
@@ -46,7 +46,7 @@ class BaseExportWidget(EntryWidget):
 
         self.list_selection = QListWidget()
         self.list_selection.addItems(list(self.main.data.lists.keys()))
-        self.list_selection.setSelectionMode(QtGui.QAbstractItemView.MultiSelection)
+        self.list_selection.setSelectionMode(QAbstractItemView.MultiSelection)
         self.list_selection.setCurrentRow(0)
         self.list_selection.setFixedHeight(18 * len(list(self.main.data.lists.keys())))
 


### PR DESCRIPTION
When I started ASCAM with qt5 I only encountered errors regarding `QAbstractItemView`. In the newer version this is moved under `QWidget` from `QtGui` and these are fixing those errors.