### PR TITLE
Platform specific requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy>=1.18
 pandas>=0.24.0
 scipy>=1.2.0
 axographio>=0.3.1
+pyobjc-framework-Cocoa>=6.2.2;sys_platform=='Darwin'

--- a/requirements_MAC.txt
+++ b/requirements_MAC.txt
@@ -4,3 +4,4 @@ numpy>=1.18
 pandas>=0.24.0
 scipy>=1.2.0
 axographio>=0.3.1
+pyobjc-framework-Cocoa>=6.2.2

--- a/requirements_MAC.txt
+++ b/requirements_MAC.txt
@@ -1,7 +1,0 @@
-pyqtgraph>=0.11.0rc0
-PySide2>=5.14.0
-numpy>=1.18
-pandas>=0.24.0
-scipy>=1.2.0
-axographio>=0.3.1
-pyobjc-framework-Cocoa>=6.2.2

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "pandas>=0.24.0",
         "scipy>=1.2.0",
         "axographio>=0.3.1",
-	"pyobjc-framework-Cocoa>=6.2.2",
+        "pyobjc-framework-Cocoa>=6.2.2;sys_platform=='Darwin'",
     ],
     entry_points={"console_scripts": ["ascam=src.ascam:main"]},
 )


### PR DESCRIPTION
macOS requires `pyobjc-framework-Cocoa`, however other operating systems do not. This PR specifies (requirements.txt and setup.py) that the `pyobcj` dependency is only required on operating system 'Darwin'.